### PR TITLE
Changed serial speed setting

### DIFF
--- a/module.json
+++ b/module.json
@@ -18,7 +18,7 @@
     }
   ],
   "dependencies": {
-    "mbed-drivers": "*"
+    "mbed-drivers": ">=0.12.0"
   },
   "targetDependencies": {},
   "bin": "./source"

--- a/source/blinky.cpp
+++ b/source/blinky.cpp
@@ -27,8 +27,7 @@ static void blinky(void) {
 
 void app_start(int, char**){
     // set 115200 baud rate for stdout
-    static Serial pc(USBTX, USBRX);
-    pc.baud(115200);
+    get_stdio_serial().baud(115200);
     minar::Scheduler::postCallback(blinky).period(minar::milliseconds(500));
 }
 


### PR DESCRIPTION
The way to set the serial speed changed starting with mbed-drivers
0.12.0. This commit updates the code to use the new way of setting
the speed.